### PR TITLE
fix cpplint stylechecking errors

### DIFF
--- a/IndividualMiniprojectC++/src/Course.cpp
+++ b/IndividualMiniprojectC++/src/Course.cpp
@@ -1,3 +1,5 @@
+/* Copyright 2024 Vidushi Bansal */
+
 #include "Course.h"
 #include <iostream>
 #include <string>

--- a/IndividualMiniprojectC++/src/Department.cpp
+++ b/IndividualMiniprojectC++/src/Department.cpp
@@ -1,3 +1,5 @@
+/* Copyright 2024 Vidushi Bansal */
+
 #include "Department.h"
 #include "Course.h"
 #include <map>

--- a/IndividualMiniprojectC++/src/Globals.cpp
+++ b/IndividualMiniprojectC++/src/Globals.cpp
@@ -1,3 +1,5 @@
+/* Copyright 2024 Vidushi Bansal */
+
 #include "Globals.h"
 
 MyFileDatabase* globalDatabase = nullptr;

--- a/IndividualMiniprojectC++/src/MyApp.cpp
+++ b/IndividualMiniprojectC++/src/MyApp.cpp
@@ -1,3 +1,5 @@
+/* Copyright 2024 Vidushi Bansal */
+
 #include "MyApp.h"
 #include <iostream>
 

--- a/IndividualMiniprojectC++/src/MyFileDatabase.cpp
+++ b/IndividualMiniprojectC++/src/MyFileDatabase.cpp
@@ -1,3 +1,5 @@
+/* Copyright 2024 Vidushi Bansal */
+
 #include "MyFileDatabase.h"
 #include <iostream>
 #include <fstream>

--- a/IndividualMiniprojectC++/src/RouteController.cpp
+++ b/IndividualMiniprojectC++/src/RouteController.cpp
@@ -1,11 +1,13 @@
+/* Copyright 2024 Vidushi Bansal */
+
 #include "RouteController.h"
 #include "Globals.h"
 #include "MyFileDatabase.h"
-#include "crow.h"
 #include <map>
 #include <string>
-#include <exception>
 #include <iostream>
+#include <exception>
+#include "../external_libraries/Crow-1.2.0-Darwin/include/crow.h"
 
 // Utility function to handle exceptions
 crow::response handleException(const std::exception& e) {

--- a/IndividualMiniprojectC++/src/main.cpp
+++ b/IndividualMiniprojectC++/src/main.cpp
@@ -1,14 +1,16 @@
-#include "crow.h"
+/* Copyright 2024 Vidushi Bansal */
+
 #include "Course.h"
 #include "Department.h"
 #include "MyFileDatabase.h"
 #include "RouteController.h"
 #include "Globals.h"
 #include "MyApp.h"
+#include <csignal>
 #include <iostream>
 #include <map>
 #include <string>
-#include <csignal>
+#include "../external_libraries/Crow-1.2.0-Darwin/include/crow.h"
 
 /**
  *  Method to handle proper termination protocols 

--- a/IndividualMiniprojectC++/test/CourseUnitTests.cpp
+++ b/IndividualMiniprojectC++/test/CourseUnitTests.cpp
@@ -1,5 +1,7 @@
-#include <gtest/gtest.h>
+/* Copyright 2024 Vidushi Bansal */
+
 #include "Course.h" 
+#include <gtest/gtest.h>
 
 class CourseUnitTests : public ::testing::Test {
 protected:

--- a/IndividualMiniprojectC++/test/sample.cpp
+++ b/IndividualMiniprojectC++/test/sample.cpp
@@ -1,3 +1,5 @@
+/* Copyright 2024 Vidushi Bansal */
+
 #include <gtest/gtest.h>
 
 // Demonstrate some basic assertions.


### PR DESCRIPTION
To fix cpplint errors in respective .cpp files
- Added copyright information
- Added header path 
- Changed order of include files 